### PR TITLE
Remove misleading reference to WCS

### DIFF
--- a/pages/about-deegree.md
+++ b/pages/about-deegree.md
@@ -115,7 +115,7 @@ deegree is a standards-based Java framework for spatial data infrastructures.
 
 Interoperability is a major driver for the development of deegree. Besides being free software - which already is an important aspect of openness and hence interoperability - it implements geospatial IT standards and uses general IT technology. deegree implements the major standards of the Open Geospatial Consortium (OGC) and the ISO Technical Committee 211. deegree core subsystems like the geometry or the metadata model are based on ISO 19107 (Geographic information -- Spatial schema) and ISO 19115 (Geographic information -- Metadata).
 
-deegree web services and other applications use these core modules. They are implementations of OGC specifications, such as Web Map Service (WMS), Web Feature Service (WFS), Catalogue Service (CSW), Web Coverage Service (WCS) and Web Processing Service (WPS).
+deegree web services and other applications use these core modules. They are implementations of OGC specifications, such as Web Map Service (WMS), Web Feature Service (WFS), Catalogue Service (CSW) and Web Processing Service (WPS).
 
 #### Java technology
 

--- a/pages/pages-root-folder/index.md
+++ b/pages/pages-root-folder/index.md
@@ -47,7 +47,7 @@ deegree is open source software for spatial data infrastructures and the geospat
 
 [Download](/download) - [Documentation](/documentation) - [Community Support](/community)
 
-The software is built on the standards of the Open Geospatial Consortium (OGC) and the ISO Technical Committee 211. It includes the OGC Web Map Service (WMS) reference implementation, a fully compliant Web Feature Service (WFS) as well as packages for Catalogue Service (CSW), Web Coverage Service (WCS), Web Processing Service (WPS) and Web Map Tile Service (WMTS). Since 2000 deegree has been developed by lat/lon, with the strong intention to make it a community-driven project. A major step to this effect was the acceptance to be an OSGeo project in 2010. Today, deegree is maintained by several organisations and individuals with a large user base all around the world.
+The software is built on the standards of the Open Geospatial Consortium (OGC) and the ISO Technical Committee 211. It includes the OGC Web Map Service (WMS) reference implementation, a fully compliant Web Feature Service (WFS) as well as packages for Catalogue Service (CSW), Web Processing Service (WPS) and Web Map Tile Service (WMTS). Since 2000 deegree has been developed by lat/lon, with the strong intention to make it a community-driven project. A major step to this effect was the acceptance to be an OSGeo project in 2010. Today, deegree is maintained by several organisations and individuals with a large user base all around the world.
 
 ![Figure: One of deegree's demo workspaces: A web mapping setup based on data from the state of Utah.]({{ site.urlimg }}console_workspace_utah2.jpg)
 Figure: One of deegree's demo workspaces: A web mapping setup based on data from the state of Utah.


### PR DESCRIPTION
This PR removes the WCS references on the homepage, expect the one in "Short History" at https://www.deegree.org/about-deegree/ where WCS is mentioned as a feature of deegree 1 and 2 only.

This PR should be closed if the TMC decides to keep the references on the homepage.

Refrences:
* https://github.com/deegree/deegree3/issues/1753