### PR TITLE
Publish deegree webservices 3.5.15 bugfix version

### DIFF
--- a/pages/documentation.md
+++ b/pages/documentation.md
@@ -12,6 +12,8 @@ This is the official user documentation ("handbook") for deegree webservices.
 
 ### deegree webservices 3.5
 
+  * 3.5.15 Released July 25, 2025 &#124; [HTML](https://download.deegree.org/documentation/3.5.15/html/) &#124; [PDF](https://download.deegree.org/documentation/3.5.15/deegree-webservices-handbook-3.5.15.pdf)
+  * 3.5.14 Released June 29, 2025 &#124; [HTML](https://download.deegree.org/documentation/3.5.14/html/) &#124; [PDF](https://download.deegree.org/documentation/3.5.14/deegree-webservices-handbook-3.5.14.pdf)
   * 3.5.13 Released May 30, 2025 &#124; [HTML](https://download.deegree.org/documentation/3.5.13/html/) &#124; [PDF](https://download.deegree.org/documentation/3.5.13/deegree-webservices-handbook-3.5.13.pdf)  
   * 3.5.12 Released April 16, 2025 &#124; [HTML](https://download.deegree.org/documentation/3.5.12/html/) &#124; [PDF](https://download.deegree.org/documentation/3.5.12/deegree-webservices-handbook-3.5.12.pdf)  
   * 3.5.11 Released April 3, 2025 &#124; [HTML](https://download.deegree.org/documentation/3.5.11/html/) &#124; [PDF](https://download.deegree.org/documentation/3.5.11/deegree-webservices-handbook-3.5.11.pdf)  

--- a/pages/download.md
+++ b/pages/download.md
@@ -15,21 +15,21 @@ deegree is distributed as WAR files, and Docker images. Follow these installatio
 3. Once a deegree package has been downloaded, proceed with the Installation section of the [user handbook](/documentation).
 
 # Stable releases (current versions)
-## deegree webservices 3.5.13 (stable)
+## deegree webservices 3.5.15 (stable)
 
-This is the latest stable version (released May 30, 2025).
+This is the latest stable version (released July 25, 2025).
  
 * Docker Image:  
 Download the official Docker Image from Docker Hub. Ready to use container with **OpenJDK 11** and Apache Tomcat 9.0.  
 [Pull Docker Image](https://hub.docker.com/r/deegree/deegree3-docker/tags?page=1&name=3.5)
 * Java Web Archive (.war):  
 Generic Java Web archive. In order to use it, you need to have a Java Servlet 3.1 container and **Java 11** installed on your machine.  
-[Download WAR](https://repo.deegree.org/content/repositories/public/org/deegree/deegree-webservices/3.5.13/deegree-webservices-3.5.13.war) 
+[Download WAR](https://repo.deegree.org/content/repositories/public/org/deegree/deegree-webservices/3.5.15/deegree-webservices-3.5.15.war) 
 * GML Tools CLI (.jar):  
 Commandline tools for deegree. In order to use it, you need to have **Java 11** installed on your machine.  
-[Download JAR](https://repo.deegree.org/repository/releases/org/deegree/deegree-tools-gml/3.5.13/deegree-tools-gml-3.5.13.jar)
+[Download JAR](https://repo.deegree.org/repository/releases/org/deegree/deegree-tools-gml/3.5.15/deegree-tools-gml-3.5.15.jar)
 
-[Changelog](https://github.com/deegree/deegree3/pulls?q=is%3Apr+is%3Amerged+milestone%3A3.5.13+) | [User handbook](https://download.deegree.org/documentation/3.5.13/html/) | [Installation](https://download.deegree.org/documentation/3.5.13/html/index.html#anchor-installation) | [Upgrade Guide](https://github.com/deegree/deegree3/wiki/Upgrading-deegree-webservices#from-34x-to-350)
+[Changelog](https://github.com/deegree/deegree3/pulls?q=is%3Apr+is%3Amerged+milestone%3A3.5.15+) | [User handbook](https://download.deegree.org/documentation/3.5.15/html/) | [Installation](https://download.deegree.org/documentation/3.5.15/html/index.html#anchor-installation) | [Upgrade Guide](https://github.com/deegree/deegree3/wiki/Upgrading-deegree-webservices#from-34x-to-350)
 
 ## deegree ogcapi 1.3.6 (stable)
 
@@ -64,6 +64,8 @@ We are recommending to update to the most recent stable version of deegree. The 
 <span style="text-decoration: underline;">**WARNING:**</span> These archived versions are only provided for software development purposes, e.g. comparing differences in behavior between earlier deegree versions, and should in <span style="text-decoration: underline;">no</span> circumstance be used for new installations in production environments!
 
 {% capture accordion_body %}
+* 3.5.14 Released June 29, 2025 &#124; [WAR](https://repo.deegree.org/content/repositories/public/org/deegree/deegree-webservices/3.5.14/deegree-webservices-3.5.14.war) &#124; [Changelog](https://github.com/deegree/deegree3/pulls?q=is:pr+is:closed+is:merged+milestone:3.5.14)
+* 3.5.13 Released May 30, 2025 &#124; [WAR](https://repo.deegree.org/content/repositories/public/org/deegree/deegree-webservices/3.5.13/deegree-webservices-3.5.13.war) &#124; [Changelog](https://github.com/deegree/deegree3/pulls?q=is:pr+is:closed+is:merged+milestone:3.5.13)
 * 3.5.12 Released April 16, 2025 &#124; [WAR](https://repo.deegree.org/content/repositories/public/org/deegree/deegree-webservices/3.5.12/deegree-webservices-3.5.12.war) &#124; [Changelog](https://github.com/deegree/deegree3/pulls?q=is:pr+is:closed+is:merged+milestone:3.5.12)
 * 3.5.11 Released April 3, 2025 &#124; [WAR](https://repo.deegree.org/content/repositories/public/org/deegree/deegree-webservices/3.5.11/deegree-webservices-3.5.11.war) &#124; [Changelog](https://github.com/deegree/deegree3/pulls?q=is:pr+is:closed+is:merged+milestone:3.5.11)
 * 3.5.10 Released January 23, 2025 &#124; [WAR](https://repo.deegree.org/content/repositories/public/org/deegree/deegree-webservices/3.5.10/deegree-webservices-3.5.10.war) &#124; [Changelog](https://github.com/deegree/deegree3/pulls?q=is:pr+is:closed+is:merged+milestone:3.5.10)


### PR DESCRIPTION
This PR updates the deegree-webservices documentation for bugfix version 3.5.15. It also includes the necessary changes for the previous bugfix version 3.5.14. 