### PR TITLE
Publish deegree webservices 3.6.6 and deegree ogcapi 2.0.4 bugfix versions

### DIFF
--- a/pages/documentation.md
+++ b/pages/documentation.md
@@ -12,6 +12,7 @@ This is the official user documentation ("handbook") for deegree webservices.
 
 ### deegree webservices 3.6
 
+* 3.6.7 Released March 13, 2026 &#124; [HTML](https://download.deegree.org/documentation/3.6.7/html/) &#124; [PDF](https://download.deegree.org/documentation/3.6.7/deegree-webservices.pdf)
 * 3.6.6 Released January 29, 2026 &#124; [HTML](https://download.deegree.org/documentation/3.6.6/html/) &#124; [PDF](https://download.deegree.org/documentation/3.6.6/deegree-webservices.pdf)
 * 3.6.5 Released December 13, 2025 &#124; [HTML](https://download.deegree.org/documentation/3.6.5/html/) &#124; [PDF](https://download.deegree.org/documentation/3.6.5/deegree-webservices.pdf)
 * 3.6.4 Released December 4, 2025 &#124; [HTML](https://download.deegree.org/documentation/3.6.4/html/) &#124; [PDF](https://download.deegree.org/documentation/3.6.4/deegree-webservices.pdf)
@@ -121,6 +122,7 @@ This is the official user documentation ("handbook") for deegree webservices.
 -->
 ### deegree ogcapi 2.0
 
+* 2.0.4  Released March 13, 2026 &#124; [HTML](https://download.deegree.org/ogcapi/documentation/2.0.4/html/) &#124; [PDF](https://download.deegree.org/ogcapi/documentation/2.0.4/deegree-ogcapi.pdf)
 * 2.0.3  Released February 14, 2026 &#124; [HTML](https://download.deegree.org/ogcapi/documentation/2.0.3/html/) &#124; [PDF](https://download.deegree.org/ogcapi/documentation/2.0.3/deegree-ogcapi.pdf)
 * 2.0.2  Released December 13, 2025 &#124; [HTML](https://download.deegree.org/ogcapi/documentation/2.0.2/html/) &#124; [PDF](https://download.deegree.org/ogcapi/documentation/2.0.2/deegree-ogcapi.pdf)
 * 2.0.1  Released December 4, 2025 &#124; [HTML](https://download.deegree.org/ogcapi/documentation/2.0.1/html/) &#124; [PDF](https://download.deegree.org/ogcapi/documentation/2.0.1/deegree-ogcapi.pdf)

--- a/pages/download.md
+++ b/pages/download.md
@@ -16,21 +16,21 @@ deegree is distributed as WAR files, and Docker images. Follow these installatio
 
 # Stable releases (current versions)
 
-## deegree webservices 3.6.6 (stable)
+## deegree webservices 3.6.7 (stable)
 
-This is the latest stable version (released January 29, 2026).
+This is the latest stable version (released March 13, 2026).
 
 * Docker Image:  
   Download the official Docker Image from Docker Hub. Ready to use container with **OpenJDK 17** and Apache Tomcat 10.1.  
   [Pull Docker Image](https://hub.docker.com/r/deegree/deegree3-docker/tags?page=1&name=3.6)
 * Java Web Archive (.war):  
   Generic Java Web archive. In order to use it, you need to have a Java Servlet 6.0 container and **Java 17** installed on your machine.  
-  [Download WAR](https://repo.deegree.org/content/repositories/public/org/deegree/deegree-webservices/3.6.6/deegree-webservices-3.6.6.war)
+  [Download WAR](https://repo.deegree.org/content/repositories/public/org/deegree/deegree-webservices/3.6.7/deegree-webservices-3.6.7.war)
 * GML Tools CLI (.jar):  
   Commandline tools for deegree. In order to use it, you need to have **Java 17** installed on your machine.  
-  [Download JAR](https://repo.deegree.org/repository/releases/org/deegree/deegree-tools-gml/3.6.6/deegree-tools-gml-3.6.6.jar)
+  [Download JAR](https://repo.deegree.org/repository/releases/org/deegree/deegree-tools-gml/3.6.7/deegree-tools-gml-3.6.7.jar)
 
-[Changelog](https://github.com/deegree/deegree3/releases/tag/deegree-3.6.6) | [User handbook](https://download.deegree.org/documentation/3.6.6/html/) | [Installation](https://download.deegree.org/documentation/3.6.6/html/index.html#anchor-installation) | [Upgrade Guide](https://github.com/deegree/deegree3/wiki/Upgrading-deegree-webservices#from-35x-to-360)
+[Changelog](https://github.com/deegree/deegree3/releases/tag/deegree-3.6.7) | [User handbook](https://download.deegree.org/documentation/3.6.7/html/) | [Installation](https://download.deegree.org/documentation/3.6.7/html/index.html#anchor-installation) | [Upgrade Guide](https://github.com/deegree/deegree3/wiki/Upgrading-deegree-webservices#from-35x-to-360)
 
 ## deegree webservices 3.5.17 (stable)
 
@@ -48,9 +48,9 @@ Commandline tools for deegree. In order to use it, you need to have **Java 11** 
 
 [Changelog](https://github.com/deegree/deegree3/pulls?q=is%3Apr+is%3Amerged+milestone%3A3.5.17+) | [User handbook](https://download.deegree.org/documentation/3.5.17/html/) | [Installation](https://download.deegree.org/documentation/3.5.17/html/index.html#anchor-installation) | [Upgrade Guide](https://github.com/deegree/deegree3/wiki/Upgrading-deegree-webservices#from-34x-to-350)
 
-## deegree ogcapi 2.0.3 (stable)
+## deegree ogcapi 2.0.4 (stable)
 
-This is the latest stable version (released February 13, 2026) based on deegree core API v3.6.
+This is the latest stable version (released March 13, 2026) based on deegree core API v3.6.
 
 * Docker Image:  
   Download the official Docker Image from Docker Hub. Ready to use container with **OpenJDK 17** and Apache Tomcat 10.1.
@@ -59,9 +59,9 @@ This is the latest stable version (released February 13, 2026) based on deegree 
 * Java Web Archive (.war):  
   Generic Java Web archive. In order to use it, you need to have a Java Servlet 6.0 container and **Java 17** installed on your machine.
   Available for PostgreSQL, Microsoft SQL Server and Oracle Database.  
-  [Download WAR](https://repo.deegree.org/#browse/search/maven=attributes.maven2.artifactId%3Ddeegree-ogcapi-webapp-*%20AND%20version%3D2.0.3)
+  [Download WAR](https://repo.deegree.org/#browse/search/maven=attributes.maven2.artifactId%3Ddeegree-ogcapi-webapp-*%20AND%20version%3D2.0.4)
 
-[Changelog](https://github.com/deegree/deegree-ogcapi/releases/tag/deegree-ogcapi-2.0.3) | [User handbook](https://download.deegree.org/ogcapi/documentation/2.0.3/html/) | [Installation](https://github.com/deegree/deegree-ogcapi/blob/main/deegree-ogcapi-documentation/src/main/asciidoc/installation.adoc)
+[Changelog](https://github.com/deegree/deegree-ogcapi/releases/tag/deegree-ogcapi-2.0.4) | [User handbook](https://download.deegree.org/ogcapi/documentation/2.0.4/html/) | [Installation](https://github.com/deegree/deegree-ogcapi/blob/main/deegree-ogcapi-documentation/src/main/asciidoc/installation.adoc)
 
 ## deegree ogcapi 1.3.9 (stable)
 
@@ -98,6 +98,7 @@ We are recommending to update to the most recent stable version of deegree. The 
 <span style="text-decoration: underline;">**WARNING:**</span> These archived versions are only provided for software development purposes, e.g. comparing differences in behavior between earlier deegree versions, and should in <span style="text-decoration: underline;">no</span> circumstance be used for new installations in production environments!
 
 {% capture accordion_body %}
+* 3.6.6 Released January 29, 2026 &#124; [WAR](https://repo.deegree.org/content/repositories/public/org/deegree/deegree-webservices/3.6.6/deegree-webservices-3.6.6.war) &#124; [Changelog](https://github.com/deegree/deegree3/releases/tag/deegree-3.6.6)
 * 3.6.5 Released December 13, 2025 &#124; [WAR](https://repo.deegree.org/content/repositories/public/org/deegree/deegree-webservices/3.6.5/deegree-webservices-3.6.5.war) &#124; [Changelog](https://github.com/deegree/deegree3/releases/tag/deegree-3.6.5)
 * 3.6.4 Released December 4, 2025 &#124; [WAR](https://repo.deegree.org/content/repositories/public/org/deegree/deegree-webservices/3.6.4/deegree-webservices-3.6.4.war) &#124; [Changelog](https://github.com/deegree/deegree3/releases/tag/deegree-3.6.4)
 * 3.6.3 Released November 14, 2025 &#124; [WAR](https://repo.deegree.org/content/repositories/public/org/deegree/deegree-webservices/3.6.3/deegree-webservices-3.6.3.war) &#124; [Changelog](https://github.com/deegree/deegree3/releases/tag/deegree-3.6.3)


### PR DESCRIPTION
This PR updates the deegree webservices documentation for bugfix version 3.6.6 as well as the deegree ogcapi documentation for bugfix version 2.0.4.